### PR TITLE
Cuckoo Hashing

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,7 +1,6 @@
 {
   "typescript.tsdk": "./node_modules/typescript/lib",
   "editor.tabSize": 2,
-  "editor.wordWrap": true,
-  "editor.wrappingColumn": 120,
+  "editor.wordWrap": "on",
   "editor.rulers": [120]
 }

--- a/src/babylon/components/Scene.tsx
+++ b/src/babylon/components/Scene.tsx
@@ -5,6 +5,7 @@ import DatasetParser from '../tools/data/DatasetParser';
 import fragmentShader from '../shaders/dvr.fragment.glsl';
 import vertexShader from '../shaders/dvr.vertex.glsl';
 import composeFragmentShader from '../shaders/compose.fragment.glsl';
+import UInt64 from '../../types/uint64';
 
 export interface SceneProps {
   width: number;
@@ -116,10 +117,10 @@ export default class Scene extends React.Component<SceneProps, SceneState> {
     // Selected Segment Hash Texture
     const selectionHash = new Cuckoo(this.scene, DataType.UInt64, 'identity', 'fnv1a');
     for (let i = 500; i < 1000; ++i) {
-      selectionHash.set(i, 0);
+      selectionHash.set(new UInt64(i, 0));
     }
     for (let i = 3000; i < 3500; ++i) {
-      selectionHash.set(i, 0);
+      selectionHash.set(new UInt64(i, 0));
     }
     /*for (let i = 0; i < 35000; ++i) {
        selectionHash.set(i, 0);
@@ -168,8 +169,8 @@ export default class Scene extends React.Component<SceneProps, SceneState> {
     // Uniforms
     frontplaneMaterial.setVector3('distortionCorrection', distort);
     frontplaneMaterial.setFloat('fovy', this.camera.fov);
-    frontplaneMaterial.setVector2('seeds', selectionHash.seeds);
-    frontplaneMaterial.setVector3('sizes', selectionHash.sizes);
+    frontplaneMaterial.setVector2('seeds', selectionHash.getSeeds());
+    frontplaneMaterial.setVector3('sizes', selectionHash.getSizes());
     frontplaneMaterial.setTexture('cubeTex', cubeTex);
     frontplaneMaterial.setTexture('selectionTex', selectionHash.texture);
 

--- a/src/babylon/tools/data/CuckooHash.tsx
+++ b/src/babylon/tools/data/CuckooHash.tsx
@@ -1,23 +1,16 @@
 import BABYLON from 'babylonjs';
 import Hash from './HashFunction';
-import { hashtype } from './HashFunction';
-
-export const enum DataType {
-  UInt8 = 0,
-  UInt16 = 1,
-  UInt32 = 2,
-  UInt64 = 3,
-  Float32 = 4,
-}
+import { HashType } from './HashFunction';
+import UInt64 from '../../../types/uint64';
 
 interface DataTypeProperties {
   dataType: DataType;
   bytePerElement: number;
 
-  getBufferValue(dataview: DataView, pos: number): [number, number];
-  setBufferValue(dataview: DataView, pos: number, lo: number, hi?: number): void;
+  getBufferValue(dataview: DataView, pos: number): UInt64 | undefined;
+  setBufferValue(dataview: DataView, pos: number, value: UInt64): void;
   texImage2D(gl: WebGL2RenderingContext, width: number, height: number, data?: ArrayBufferView): void;
-  texSubImage2D(gl: WebGL2RenderingContext, x: number, y: number, lo: number, hi?: number): void;
+  texSubImage2D(gl: WebGL2RenderingContext, x: number, y: number, value: UInt64): void;
 }
 
 interface HashTableSize {
@@ -27,11 +20,18 @@ interface HashTableSize {
   maxsize: number;
 }
 
+export const enum DataType {
+  UInt8 = 0,
+  UInt16 = 1,
+  UInt32 = 2,
+  UInt64 = 3,
+}
+
 export class Cuckoo {
-  private static _instance: number;
+  private static instance: number;
 
   // Prime numbers as hash table size might help with fast, dumb hash functions, e.g. f(n) = n
-  private static readonly _sizeLookup: HashTableSize[] = [
+  private static readonly sizeLookup: HashTableSize[] = [
     { level: 0, texwidth:  256, texheight:  256, maxsize:    65521 }, //  256 *  256
     { level: 1, texwidth:  512, texheight:  512, maxsize:   262139 }, //  512 *  512
     { level: 2, texwidth: 1024, texheight: 1024, maxsize:  1048573 }, // 1024 * 1024
@@ -40,22 +40,23 @@ export class Cuckoo {
     { level: 5, texwidth: 8192, texheight: 8192, maxsize: 67108859 }, // 8192 * 8192
   ];
 
-  private static readonly _dataTypeLookup: DataTypeProperties[] = [
+  private static readonly dataTypeLookup: DataTypeProperties[] = [
     {
       dataType: DataType.UInt8,
       bytePerElement: 1,
 
       getBufferValue: function(dataview, pos) {
-        return [dataview.getUint8(pos), 0];
+        const res = dataview.getUint8(pos);
+        return res === 0 ? undefined : new UInt64(res, 0);
       },
       setBufferValue: function(dataview, pos, val) {
-        dataview.setUint8(pos, val);
+        dataview.setUint8(pos, val.low);
       },
       texImage2D: function(gl, width, height, data) {
         gl.texImage2D(gl.TEXTURE_2D, 0, gl.R8UI, width, height, 0, gl.RED_INTEGER, gl.UNSIGNED_BYTE, data);
       },
       texSubImage2D: function(gl, x, y, val) {
-        gl.texSubImage2D(gl.TEXTURE_2D, 0, x, y, 1, 1, gl.RED_INTEGER, gl.UNSIGNED_BYTE, new Uint8Array([val]));
+        gl.texSubImage2D(gl.TEXTURE_2D, 0, x, y, 1, 1, gl.RED_INTEGER, gl.UNSIGNED_BYTE, new Uint8Array([val.low]));
       },
     },
     {
@@ -63,16 +64,17 @@ export class Cuckoo {
       bytePerElement: 2,
 
       getBufferValue: function(dataview, pos) {
-        return [dataview.getUint16(2 * pos, true), 0];
+        const res = dataview.getUint16(2 * pos, true);
+        return res === 0 ? undefined : new UInt64(res, 0);
       },
       setBufferValue: function(dataview, pos, val) {
-        dataview.setUint16(2 * pos, val, true);
+        dataview.setUint16(2 * pos, val.low, true);
       },
       texImage2D: function(gl, width, height, data) {
         gl.texImage2D(gl.TEXTURE_2D, 0, gl.R16UI, width, height, 0, gl.RED_INTEGER, gl.UNSIGNED_SHORT, data);
       },
       texSubImage2D: function(gl, x, y, val) {
-        gl.texSubImage2D(gl.TEXTURE_2D, 0, x, y, 1, 1, gl.RED_INTEGER, gl.UNSIGNED_SHORT, new Uint16Array([val]));
+        gl.texSubImage2D(gl.TEXTURE_2D, 0, x, y, 1, 1, gl.RED_INTEGER, gl.UNSIGNED_SHORT, new Uint16Array([val.low]));
       },
     },
     {
@@ -80,16 +82,17 @@ export class Cuckoo {
       bytePerElement: 4,
 
       getBufferValue: function(dataview, pos) {
-        return [dataview.getUint32(4 * pos, true), 0];
+        const res = dataview.getUint32(4 * pos, true);
+        return res === 0 ? undefined : new UInt64(res, 0);
       },
       setBufferValue: function(dataview, pos, val) {
-        dataview.setUint32(4 * pos, val, true);
+        dataview.setUint32(4 * pos, val.low, true);
       },
       texImage2D: function(gl, width, height, data) {
         gl.texImage2D(gl.TEXTURE_2D, 0, gl.R32UI, width, height, 0, gl.RED_INTEGER, gl.UNSIGNED_INT, data);
       },
       texSubImage2D: function(gl, x, y, val) {
-        gl.texSubImage2D(gl.TEXTURE_2D, 0, x, y, 1, 1, gl.RED_INTEGER, gl.UNSIGNED_INT, new Uint32Array([val]));
+        gl.texSubImage2D(gl.TEXTURE_2D, 0, x, y, 1, 1, gl.RED_INTEGER, gl.UNSIGNED_INT, new Uint32Array([val.low]));
       },
     },
     {
@@ -97,273 +100,257 @@ export class Cuckoo {
       bytePerElement: 8,
 
       getBufferValue: function(dataview, pos) {
-        return [dataview.getUint32(8 * pos, true), dataview.getUint32(8 * pos + 4, true)];
+        const res = new UInt64(dataview.getUint32(8 * pos, true), dataview.getUint32(8 * pos + 4, true));
+        return res.low === 0 && res.high === 0 ? undefined : res;
       },
-      setBufferValue: function(dataview, pos, lo, hi) {
-        dataview.setUint32(8 * pos, lo, true);
-        dataview.setUint32(8 * pos + 4, hi || 0, true);
+      setBufferValue: function(dataview, pos, val) {
+        dataview.setUint32(8 * pos, val.low, true);
+        dataview.setUint32(8 * pos + 4, val.high || 0, true);
       },
       texImage2D: function(gl, width, height, data) {
         gl.texImage2D(gl.TEXTURE_2D, 0, gl.RG32UI, width, height, 0, gl.RG_INTEGER, gl.UNSIGNED_INT, data);
       },
-      texSubImage2D: function(gl, x, y, lo, hi) {
-        gl.texSubImage2D(gl.TEXTURE_2D, 0, x, y, 1, 1, gl.RG_INTEGER, gl.UNSIGNED_INT, new Uint32Array([lo, hi || 0]));
-      },
-    },
-    {
-      dataType: DataType.Float32,
-      bytePerElement: 4,
-
-      getBufferValue: function(dataview, pos) {
-        return [dataview.getFloat32(4 * pos, true), 0];
-      },
-      setBufferValue: function(dataview, pos, val) {
-        dataview.setFloat32(4 * pos, val, true);
-      },
-      texImage2D: function(gl, width, height, data) {
-        gl.texImage2D(gl.TEXTURE_2D, 0, gl.R32F, width, height, 0, gl.RED, gl.FLOAT, data);
-      },
       texSubImage2D: function(gl, x, y, val) {
-        gl.texSubImage2D(gl.TEXTURE_2D, 0, x, y, 1, 1, gl.RED, gl.FLOAT, new Float32Array([val]));
+        gl.texSubImage2D(gl.TEXTURE_2D, 0, x, y, 1, 1, gl.RG_INTEGER, gl.UNSIGNED_INT,
+          new Uint32Array([val.low, val.high || 0]));
       },
     },
   ];
 
-  private _texture: BABYLON.Texture;
-  private _type: DataTypeProperties;
-  private _sizes: HashTableSize;
-  private _setElements: number;
-  private _lastInsertError: { lo: number, hi: number };
-  private _table: ArrayBuffer;
-  private _tableView: DataView;
-  private _hashfunctions: [Hash, Hash];
+  public readonly texture: BABYLON.Texture;
+  public maxLoadFactor: number;
+  public maxRehashAttempts: number;
+  private elementCount: number;
+  private type: DataTypeProperties;
+  private hashTableSizes: HashTableSize;
+  private table: ArrayBuffer;
+  private tableView: DataView;
+  private hashFunctions: [Hash, Hash];
+  private seeds: BABYLON.Vector2;
+  private sizes: BABYLON.Vector3;
 
-  constructor(private _scene: BABYLON.Scene, valueType: DataType, private _hashFuncA: hashtype = 'identity',
-              private _hashFuncB: hashtype = 'fnv1a') {
-    Cuckoo._instance = (Cuckoo._instance === undefined) ? 0 : ++Cuckoo._instance;
+  constructor(private scene: BABYLON.Scene, valueType: DataType, private hashFuncA: HashType = 'identity',
+              private hashFuncB: HashType = 'fnv1a') {
+    Cuckoo.instance = (Cuckoo.instance === undefined) ? 0 : ++Cuckoo.instance;
 
-    this._texture = new BABYLON.Texture('', this._scene, true);
-    this._texture.name = `CuckooHash_${Cuckoo._instance}`;
-    this._type = Cuckoo._dataTypeLookup[valueType];
-    this._sizes = Cuckoo._sizeLookup[0];
-    this._setElements = 0;
-    this._lastInsertError = { lo: 0, hi: 0 };
-    this._table = new ArrayBuffer(this._type.bytePerElement * this._sizes.maxsize);
-    this._tableView = new DataView(this._table);
+    this.texture = new BABYLON.Texture('', this.scene, true);
+    this.texture.name = `CuckooHash_${Cuckoo.instance}`;
+    this.type = Cuckoo.dataTypeLookup[valueType];
+    this.hashTableSizes = Cuckoo.sizeLookup[0];
+    this.elementCount = 0;
+    this.table = new ArrayBuffer(this.type.bytePerElement * this.hashTableSizes.maxsize);
+    this.tableView = new DataView(this.table);
 
-    this._hashfunctions = Hash.createHashFunctions(this._hashFuncA, this._hashFuncB);
-    this._updateTexture();
+    this.hashFunctions = Hash.createHashFunctions(this.hashFuncA, this.hashFuncB);
+    this.seeds = new BABYLON.Vector2(this.hashFunctions[0].seed, this.hashFunctions[1].seed);
+    this.sizes = new BABYLON.Vector3(this.hashTableSizes.texwidth, this.hashTableSizes.texheight,
+      this.hashTableSizes.maxsize);
+
+    this.maxLoadFactor = 0.5;
+    this.maxRehashAttempts = 3;
+
+    this.updateTexture();
   }
 
-  get texture(): BABYLON.Texture {
-    return this._texture;
+  public getElementCount() {
+    return this.elementCount;
   }
 
-  get seeds(): BABYLON.Vector2 {
-    return new BABYLON.Vector2(this._hashfunctions[0].seed, this._hashfunctions[1].seed);
+  public getSeeds(): BABYLON.Vector2 {
+    return this.seeds;
   }
 
-  get sizes(): BABYLON.Vector3 {
-    return new BABYLON.Vector3(this._sizes.texwidth, this._sizes.texheight, this._sizes.maxsize);
+  public getSizes(): BABYLON.Vector3 {
+    return this.sizes;
   }
 
-  get loadFactor(): number {
-    return this._setElements / this._sizes.maxsize;
+  public getLoadFactor(): number {
+    return this.elementCount / this.hashTableSizes.maxsize;
   }
 
-  public clearLastInsertError() {
-    this._lastInsertError.lo = 0;
-    this._lastInsertError.hi = 0;
-  }
+  public set(key: UInt64): boolean {
+    let rehashAttempts = 0;
+    let errors: UInt64[] = [key];
+    let needRehash = false;
 
-  public getLastInsertError(): { lo: number, hi: number } {
-    return { lo: this._lastInsertError.lo, hi: this._lastInsertError.hi };
-  }
-
-  public set(lo: number, hi: number = 0): boolean {
-    if (this._set(lo, hi, 0, []) === false) {
-      return this._rehash();
-    }
-    return true;
-  }
-
-  public unset(lo: number, hi: number = 0): boolean {
-    let pos = this._hashfunctions[0].compute(lo, hi) % this._sizes.maxsize;
-    let [loOld, hiOld] = this._getValue(pos);
-    if (loOld === lo && hiOld === hi) {
-      this._setValue(pos, 0, 0);
-      --this._setElements;
-      return true;
+    // If we resize, we have to do a full rehash
+    if (this.getLoadFactor() > this.maxLoadFactor) {
+      if (this.resize() === true) {
+        --rehashAttempts;
+        needRehash = true;
+      }
     }
 
-    pos = this._hashfunctions[1].compute(lo, hi) % this._sizes.maxsize;
-    [loOld, hiOld] = this._getValue(pos);
-    if (loOld === lo && hiOld === hi) {
-      this._setValue(pos, 0, 0);
-      --this._setElements;
+    while (errors.length > 0 && rehashAttempts < this.maxRehashAttempts) {
+      let rehashError = undefined;
+      if (needRehash) {
+        rehashError = this.rehash();
+        ++rehashAttempts;
+        if (rehashError) {
+          errors.push(rehashError);
+        } else {
+          needRehash = false;
+        }
+      }
+
+      let currentKey = errors.pop();
+      let setError = this.setKey(currentKey!, 0, []);
+      if (!setError.success) {
+        errors.push(setError.key!);
+        needRehash = true;
+      }
     }
 
-    return true;
+    return errors.length === 0;
   }
 
-  public isset(lo: number, hi: number = 0): boolean {
-    let pos = this._hashfunctions[0].compute(lo, hi) % this._sizes.maxsize;
-    let [loOld, hiOld] = this._getValue(pos);
-    if (loOld === lo && hiOld === hi) {
-      return true;
-    }
+  public unset(key: UInt64): boolean {
+    return this.hashFunctions.some((element): boolean => {
+      let pos = element.compute(key) % this.hashTableSizes.maxsize;
+      let oldKey = this.getBufferValue(pos);
+      if (oldKey !== undefined && oldKey.low === key.low && oldKey.high === key.high) {
+        this.setBufferValue(pos, new UInt64(0, 0));
+        --this.elementCount;
+        return true;
+      }
+      return false;
+    });
+  }
 
-    pos = this._hashfunctions[1].compute(lo, hi) % this._sizes.maxsize;
-    [loOld, hiOld] = this._getValue(pos);
-    if (loOld === lo && hiOld === hi) {
-      return true;
-    }
-
-    return false;
+  public isSet(key: UInt64): boolean {
+    return this.hashFunctions.some((element): boolean => {
+      let pos = element.compute(key) % this.hashTableSizes.maxsize;
+      let oldKey = this.getBufferValue(pos);
+      return oldKey !== undefined && oldKey.low === key.low && oldKey.high === key.high;
+    });
   }
 
   // TODO: Speedup - painfully slow
-  private _rehash(): boolean {
-    let retries = 0;
-    let tmp = this.getLastInsertError();
+  private rehash(): UInt64 | undefined {
+    console.log(`Rehash called!`);
 
-    while (retries < 3) {
-      // Create new hash functions
-      this._hashfunctions = Hash.createHashFunctions(this._hashFuncA, this._hashFuncB);
+    // Create new hash functions
+    this.hashFunctions = Hash.createHashFunctions(this.hashFuncA, this.hashFuncB);
+    this.seeds.x = this.hashFunctions[0].seed;
+    this.seeds.y = this.hashFunctions[1].seed;
 
-      // If last rehash failed, insert the causative element first to ensure every element is represented once.
-      if (tmp.lo > 0 || tmp.hi > 0) {
-        if (this._set(tmp.lo, tmp.hi, 0, []) === false) {
-          ++retries;
-        }
-        tmp = this.getLastInsertError();
-      }
-
-      if (tmp.lo === 0 && tmp.hi === 0) {
-        for (let pos = 0; pos < Cuckoo._sizeLookup[this._sizes.level].maxsize; ++pos) {
-          const [lo, hi] = this._type.getBufferValue(this._tableView, pos);
-          if ((lo > 0 || hi > 0) && this.isset(lo, hi) === false) {
-            this._type.setBufferValue(this._tableView, pos, 0, 0);
-            --this._setElements;
-            if (this._set(lo, hi, 0, []) === false) {
-              ++retries;
-              tmp = this.getLastInsertError();
-              break;
-            }
-          }
+    // Move all elements in hash table to new places
+    for (let pos = 0; pos < Cuckoo.sizeLookup[this.hashTableSizes.level].maxsize; ++pos) {
+      const key = this.type.getBufferValue(this.tableView, pos);
+      if (key !== undefined && this.isSet(key) === false) {
+        this.type.setBufferValue(this.tableView, pos, new UInt64(0, 0));
+        --this.elementCount;
+        let result = this.setKey(key, 0, []);
+        // Abort rehash if element couldn't be added, append to error list and return
+        if (result.success === false) {
+          return result.key;
         }
       }
-
-      if (tmp.lo === 0 && tmp.hi === 0) {
-        return true;
-      }
-    }
-    return this._resize();
-  }
-
-  private _resize(): boolean {
-    const level = this._sizes.level;
-
-    if (level + 1 < Cuckoo._sizeLookup.length) {
-      this._sizes = Cuckoo._sizeLookup[level + 1];
-
-      // Create new empty ArrayBuffer (can't resize existing one)
-      let newTable = new ArrayBuffer(this._type.bytePerElement * this._sizes.maxsize);
-      let newTableView = new DataView(newTable);
-
-      // Copy old buffer dumb way until we have ArrayBuffer.transfer()
-      for (let i = 0; i < this._tableView.byteLength; ++i) {
-        newTableView.setUint8(i, this._tableView.getUint8(i));
-      }
-      this._table = newTable;
-      this._tableView = newTableView;
-
-      this._updateTexture();
-
-      // Rehash all elements
-      return this._rehash();
     }
 
-    // Can't enlarge hash table - already at max size
-    return false;
+    return;
   }
 
-  private _updateTexture(): void {
-    const engine = this._scene.getEngine();
+  private resize(): boolean {
+    const level = this.hashTableSizes.level;
+    console.log(`Resize called! (Size: ${level})`);
+
+    if (level + 1 >= Cuckoo.sizeLookup.length) {
+      // Can't enlarge hash table - already at max size
+      return false;
+    }
+
+    this.hashTableSizes = Cuckoo.sizeLookup[level + 1];
+
+    // Create new empty ArrayBuffer (can't resize existing one)
+    let newTable = new ArrayBuffer(this.type.bytePerElement * this.hashTableSizes.maxsize);
+    let newTableView = new DataView(newTable);
+
+    // Copy old buffer dumb way until we have ArrayBuffer.transfer()
+    for (let i = 0; i < this.tableView.byteLength; ++i) {
+      newTableView.setUint8(i, this.tableView.getUint8(i));
+    }
+    this.table = newTable;
+    this.tableView = newTableView;
+    this.sizes.x = this.hashTableSizes.texwidth;
+    this.sizes.y = this.hashTableSizes.texheight;
+    this.sizes.z = this.hashTableSizes.maxsize;
+
+    this.updateTexture();
+    return true;
+  }
+
+  private updateTexture(): void {
+    const engine = this.scene.getEngine();
     const gl = engine._gl as WebGL2RenderingContext;
 
-    if (this._texture._texture !== undefined) {
-      this._texture.releaseInternalTexture();
+    if (this.texture._texture !== undefined) {
+      this.texture.releaseInternalTexture();
     }
 
-    this._texture._texture = engine.createDynamicTexture(this._sizes.texwidth, this._sizes.texheight, false,
-      BABYLON.Texture.NEAREST_SAMPLINGMODE);
+    this.texture._texture = engine.createDynamicTexture(this.hashTableSizes.texwidth, this.hashTableSizes.texheight,
+      false, BABYLON.Texture.NEAREST_SAMPLINGMODE);
 
-    gl.bindTexture(gl.TEXTURE_2D, this._texture._texture);
+    gl.bindTexture(gl.TEXTURE_2D, this.texture._texture);
 
     gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.NEAREST);
     gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.NEAREST);
     gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE);
     gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE);
-    this._type.texImage2D(gl, this._sizes.texwidth, this._sizes.texheight, undefined);
+    this.type.texImage2D(gl, this.hashTableSizes.texwidth, this.hashTableSizes.texheight, undefined);
 
     gl.bindTexture(gl.TEXTURE_2D, null);
 
-    this._texture._texture.isReady = true;
+    this.texture._texture.isReady = true;
   }
 
-  private _set(lo: number, hi: number, mode: number, history: { pos: number, lo: number, hi: number }[]): boolean {
-    const pos = this._hashfunctions[mode].compute(lo, hi) % this._sizes.maxsize;
-    const [loOld, hiOld] = this._getValue(pos);
+  private setKey(key: UInt64, mode: number, history: { pos: number, key: UInt64 }[]):
+      { success: boolean, key?: UInt64 } {
+    const pos = this.hashFunctions[mode].compute(key) % this.hashTableSizes.maxsize;
+    const oldKey = this.getBufferValue(pos);
 
-    if (loOld === 0 && hiOld === 0) {
-      this.clearLastInsertError();
-
-      this._setValue(pos, lo, hi);
-      ++this._setElements;
-      if (this.loadFactor > 0.5 && this._sizes.level + 1 < Cuckoo._sizeLookup.length) {
-        return this._resize();
-      }
-      return true;
-    } else if (loOld === lo && hiOld === hi) {
-      return true;
+    if (oldKey === undefined) {
+      this.setBufferValue(pos, key);
+      ++this.elementCount;
+      return { success: true };
+    } else if (oldKey!.low === key.low && oldKey!.high === key.high) {
+      return { success: true };
     } else {
       // Check for circuit
-      if (history.find((el) => { return el.pos === pos && el.hi === hi && el.lo === lo; })) {
-        console.log(`Collision can\'t be resolved! (Load factor: ${this.loadFactor})`);
-        this._lastInsertError = { lo: lo, hi: hi };
-        return false;
+      if (history.find((el) => { return el.pos === pos && el.key.high === key.high && el.key.low === key.low; })) {
+        console.log(`Collision can\'t be resolved! (Load factor: ${this.getLoadFactor()},
+          History Length: ${history.length})`);
+        return { success: false, key: key };
       } else {
-        this._setValue(pos, lo, hi);
+        this.setBufferValue(pos, key);
 
         // Check which seed was used for old segment and switch to alternative for new insertion
-        const posOld = this._hashfunctions[mode].compute(loOld, hiOld) % this._sizes.maxsize;
+        const posOld = this.hashFunctions[mode].compute(oldKey!) % this.hashTableSizes.maxsize;
 
         if (posOld === pos) {
           mode = 1 - mode;
         }
 
-        history.push({ pos: pos, lo: lo, hi: hi });
-        return this._set(loOld, hiOld, mode, history);
+        history.push({ pos: pos, key: key });
+        return this.setKey(oldKey!, mode, history);
       }
     }
   }
 
-  private _getValue(pos: number): [number, number] {
-    return this._type.getBufferValue(this._tableView, pos);
+  private getBufferValue(pos: number): UInt64 | undefined {
+    return this.type.getBufferValue(this.tableView, pos);
   }
 
-  private _setValue(pos: number, lo: number, hi: number = 0): void {
-    const gl = this._scene.getEngine()._gl as WebGL2RenderingContext;
+  private setBufferValue(pos: number, value: UInt64): void {
+    const gl = this.scene.getEngine()._gl as WebGL2RenderingContext;
 
-    const x_pos = pos % this._sizes.texwidth;
-    const y_pos = Math.floor(pos / this._sizes.texwidth);
+    const x_pos = pos % this.hashTableSizes.texwidth;
+    const y_pos = Math.floor(pos / this.hashTableSizes.texwidth);
 
-    this._type.setBufferValue(this._tableView, pos, lo, hi);
+    this.type.setBufferValue(this.tableView, pos, value);
 
-    gl.bindTexture(gl.TEXTURE_2D, this._texture._texture);
-    this._type.texSubImage2D(gl, x_pos, y_pos, lo, hi);
+    gl.bindTexture(gl.TEXTURE_2D, this.texture._texture);
+    this.type.texSubImage2D(gl, x_pos, y_pos, value);
     gl.bindTexture(gl.TEXTURE_2D, null);
-
   }
 }

--- a/src/babylon/tools/data/CuckooHash.tsx
+++ b/src/babylon/tools/data/CuckooHash.tsx
@@ -1,0 +1,369 @@
+import BABYLON from 'babylonjs';
+import Hash from './HashFunction';
+import { hashtype } from './HashFunction';
+
+export const enum DataType {
+  UInt8 = 0,
+  UInt16 = 1,
+  UInt32 = 2,
+  UInt64 = 3,
+  Float32 = 4,
+}
+
+interface DataTypeProperties {
+  dataType: DataType;
+  bytePerElement: number;
+
+  getBufferValue(dataview: DataView, pos: number): [number, number];
+  setBufferValue(dataview: DataView, pos: number, lo: number, hi?: number): void;
+  texImage2D(gl: WebGL2RenderingContext, width: number, height: number, data?: ArrayBufferView): void;
+  texSubImage2D(gl: WebGL2RenderingContext, x: number, y: number, lo: number, hi?: number): void;
+}
+
+interface HashTableSize {
+  level: number;
+  texwidth: number;
+  texheight: number;
+  maxsize: number;
+}
+
+export class Cuckoo {
+  private static _instance: number;
+
+  // Prime numbers as hash table size might help with fast, dumb hash functions, e.g. f(n) = n
+  private static readonly _sizeLookup: HashTableSize[] = [
+    { level: 0, texwidth:  256, texheight:  256, maxsize:    65521 }, //  256 *  256
+    { level: 1, texwidth:  512, texheight:  512, maxsize:   262139 }, //  512 *  512
+    { level: 2, texwidth: 1024, texheight: 1024, maxsize:  1048573 }, // 1024 * 1024
+    { level: 3, texwidth: 2048, texheight: 2048, maxsize:  4194301 }, // 2048 * 2048
+    { level: 4, texwidth: 4096, texheight: 4096, maxsize: 16777213 }, // 4096 * 4096
+    { level: 5, texwidth: 8192, texheight: 8192, maxsize: 67108859 }, // 8192 * 8192
+  ];
+
+  private static readonly _dataTypeLookup: DataTypeProperties[] = [
+    {
+      dataType: DataType.UInt8,
+      bytePerElement: 1,
+
+      getBufferValue: function(dataview, pos) {
+        return [dataview.getUint8(pos), 0];
+      },
+      setBufferValue: function(dataview, pos, val) {
+        dataview.setUint8(pos, val);
+      },
+      texImage2D: function(gl, width, height, data) {
+        gl.texImage2D(gl.TEXTURE_2D, 0, gl.R8UI, width, height, 0, gl.RED_INTEGER, gl.UNSIGNED_BYTE, data);
+      },
+      texSubImage2D: function(gl, x, y, val) {
+        gl.texSubImage2D(gl.TEXTURE_2D, 0, x, y, 1, 1, gl.RED_INTEGER, gl.UNSIGNED_BYTE, new Uint8Array([val]));
+      },
+    },
+    {
+      dataType: DataType.UInt16,
+      bytePerElement: 2,
+
+      getBufferValue: function(dataview, pos) {
+        return [dataview.getUint16(2 * pos, true), 0];
+      },
+      setBufferValue: function(dataview, pos, val) {
+        dataview.setUint16(2 * pos, val, true);
+      },
+      texImage2D: function(gl, width, height, data) {
+        gl.texImage2D(gl.TEXTURE_2D, 0, gl.R16UI, width, height, 0, gl.RED_INTEGER, gl.UNSIGNED_SHORT, data);
+      },
+      texSubImage2D: function(gl, x, y, val) {
+        gl.texSubImage2D(gl.TEXTURE_2D, 0, x, y, 1, 1, gl.RED_INTEGER, gl.UNSIGNED_SHORT, new Uint16Array([val]));
+      },
+    },
+    {
+      dataType: DataType.UInt32,
+      bytePerElement: 4,
+
+      getBufferValue: function(dataview, pos) {
+        return [dataview.getUint32(4 * pos, true), 0];
+      },
+      setBufferValue: function(dataview, pos, val) {
+        dataview.setUint32(4 * pos, val, true);
+      },
+      texImage2D: function(gl, width, height, data) {
+        gl.texImage2D(gl.TEXTURE_2D, 0, gl.R32UI, width, height, 0, gl.RED_INTEGER, gl.UNSIGNED_INT, data);
+      },
+      texSubImage2D: function(gl, x, y, val) {
+        gl.texSubImage2D(gl.TEXTURE_2D, 0, x, y, 1, 1, gl.RED_INTEGER, gl.UNSIGNED_INT, new Uint32Array([val]));
+      },
+    },
+    {
+      dataType: DataType.UInt64,
+      bytePerElement: 8,
+
+      getBufferValue: function(dataview, pos) {
+        return [dataview.getUint32(8 * pos, true), dataview.getUint32(8 * pos + 4, true)];
+      },
+      setBufferValue: function(dataview, pos, lo, hi) {
+        dataview.setUint32(8 * pos, lo, true);
+        dataview.setUint32(8 * pos + 4, hi || 0, true);
+      },
+      texImage2D: function(gl, width, height, data) {
+        gl.texImage2D(gl.TEXTURE_2D, 0, gl.RG32UI, width, height, 0, gl.RG_INTEGER, gl.UNSIGNED_INT, data);
+      },
+      texSubImage2D: function(gl, x, y, lo, hi) {
+        gl.texSubImage2D(gl.TEXTURE_2D, 0, x, y, 1, 1, gl.RG_INTEGER, gl.UNSIGNED_INT, new Uint32Array([lo, hi || 0]));
+      },
+    },
+    {
+      dataType: DataType.Float32,
+      bytePerElement: 4,
+
+      getBufferValue: function(dataview, pos) {
+        return [dataview.getFloat32(4 * pos, true), 0];
+      },
+      setBufferValue: function(dataview, pos, val) {
+        dataview.setFloat32(4 * pos, val, true);
+      },
+      texImage2D: function(gl, width, height, data) {
+        gl.texImage2D(gl.TEXTURE_2D, 0, gl.R32F, width, height, 0, gl.RED, gl.FLOAT, data);
+      },
+      texSubImage2D: function(gl, x, y, val) {
+        gl.texSubImage2D(gl.TEXTURE_2D, 0, x, y, 1, 1, gl.RED, gl.FLOAT, new Float32Array([val]));
+      },
+    },
+  ];
+
+  private _texture: BABYLON.Texture;
+  private _type: DataTypeProperties;
+  private _sizes: HashTableSize;
+  private _setElements: number;
+  private _lastInsertError: { lo: number, hi: number };
+  private _table: ArrayBuffer;
+  private _tableView: DataView;
+  private _hashfunctions: [Hash, Hash];
+
+  constructor(private _scene: BABYLON.Scene, valueType: DataType, private _hashFuncA: hashtype = 'identity',
+              private _hashFuncB: hashtype = 'fnv1a') {
+    Cuckoo._instance = (Cuckoo._instance === undefined) ? 0 : ++Cuckoo._instance;
+
+    this._texture = new BABYLON.Texture('', this._scene, true);
+    this._texture.name = `CuckooHash_${Cuckoo._instance}`;
+    this._type = Cuckoo._dataTypeLookup[valueType];
+    this._sizes = Cuckoo._sizeLookup[0];
+    this._setElements = 0;
+    this._lastInsertError = { lo: 0, hi: 0 };
+    this._table = new ArrayBuffer(this._type.bytePerElement * this._sizes.maxsize);
+    this._tableView = new DataView(this._table);
+
+    this._hashfunctions = Hash.createHashFunctions(this._hashFuncA, this._hashFuncB);
+    this._updateTexture();
+  }
+
+  get texture(): BABYLON.Texture {
+    return this._texture;
+  }
+
+  get seeds(): BABYLON.Vector2 {
+    return new BABYLON.Vector2(this._hashfunctions[0].seed, this._hashfunctions[1].seed);
+  }
+
+  get sizes(): BABYLON.Vector3 {
+    return new BABYLON.Vector3(this._sizes.texwidth, this._sizes.texheight, this._sizes.maxsize);
+  }
+
+  get loadFactor(): number {
+    return this._setElements / this._sizes.maxsize;
+  }
+
+  public clearLastInsertError() {
+    this._lastInsertError.lo = 0;
+    this._lastInsertError.hi = 0;
+  }
+
+  public getLastInsertError(): { lo: number, hi: number } {
+    return { lo: this._lastInsertError.lo, hi: this._lastInsertError.hi };
+  }
+
+  public set(lo: number, hi: number = 0): boolean {
+    if (this._set(lo, hi, 0, []) === false) {
+      return this._rehash();
+    }
+    return true;
+  }
+
+  public unset(lo: number, hi: number = 0): boolean {
+    let pos = this._hashfunctions[0].compute(lo, hi) % this._sizes.maxsize;
+    let [loOld, hiOld] = this._getValue(pos);
+    if (loOld === lo && hiOld === hi) {
+      this._setValue(pos, 0, 0);
+      --this._setElements;
+      return true;
+    }
+
+    pos = this._hashfunctions[1].compute(lo, hi) % this._sizes.maxsize;
+    [loOld, hiOld] = this._getValue(pos);
+    if (loOld === lo && hiOld === hi) {
+      this._setValue(pos, 0, 0);
+      --this._setElements;
+    }
+
+    return true;
+  }
+
+  public isset(lo: number, hi: number = 0): boolean {
+    let pos = this._hashfunctions[0].compute(lo, hi) % this._sizes.maxsize;
+    let [loOld, hiOld] = this._getValue(pos);
+    if (loOld === lo && hiOld === hi) {
+      return true;
+    }
+
+    pos = this._hashfunctions[1].compute(lo, hi) % this._sizes.maxsize;
+    [loOld, hiOld] = this._getValue(pos);
+    if (loOld === lo && hiOld === hi) {
+      return true;
+    }
+
+    return false;
+  }
+
+  // TODO: Speedup - painfully slow
+  private _rehash(): boolean {
+    let retries = 0;
+    let tmp = this.getLastInsertError();
+
+    while (retries < 3) {
+      // Create new hash functions
+      this._hashfunctions = Hash.createHashFunctions(this._hashFuncA, this._hashFuncB);
+
+      // If last rehash failed, insert the causative element first to ensure every element is represented once.
+      if (tmp.lo > 0 || tmp.hi > 0) {
+        if (this._set(tmp.lo, tmp.hi, 0, []) === false) {
+          ++retries;
+        }
+        tmp = this.getLastInsertError();
+      }
+
+      if (tmp.lo === 0 && tmp.hi === 0) {
+        for (let pos = 0; pos < Cuckoo._sizeLookup[this._sizes.level].maxsize; ++pos) {
+          const [lo, hi] = this._type.getBufferValue(this._tableView, pos);
+          if ((lo > 0 || hi > 0) && this.isset(lo, hi) === false) {
+            this._type.setBufferValue(this._tableView, pos, 0, 0);
+            --this._setElements;
+            if (this._set(lo, hi, 0, []) === false) {
+              ++retries;
+              tmp = this.getLastInsertError();
+              break;
+            }
+          }
+        }
+      }
+
+      if (tmp.lo === 0 && tmp.hi === 0) {
+        return true;
+      }
+    }
+    return this._resize();
+  }
+
+  private _resize(): boolean {
+    const level = this._sizes.level;
+
+    if (level + 1 < Cuckoo._sizeLookup.length) {
+      this._sizes = Cuckoo._sizeLookup[level + 1];
+
+      // Create new empty ArrayBuffer (can't resize existing one)
+      let newTable = new ArrayBuffer(this._type.bytePerElement * this._sizes.maxsize);
+      let newTableView = new DataView(newTable);
+
+      // Copy old buffer dumb way until we have ArrayBuffer.transfer()
+      for (let i = 0; i < this._tableView.byteLength; ++i) {
+        newTableView.setUint8(i, this._tableView.getUint8(i));
+      }
+      this._table = newTable;
+      this._tableView = newTableView;
+
+      this._updateTexture();
+
+      // Rehash all elements
+      return this._rehash();
+    }
+
+    // Can't enlarge hash table - already at max size
+    return false;
+  }
+
+  private _updateTexture(): void {
+    const engine = this._scene.getEngine();
+    const gl = engine._gl as WebGL2RenderingContext;
+
+    if (this._texture._texture !== undefined) {
+      this._texture.releaseInternalTexture();
+    }
+
+    this._texture._texture = engine.createDynamicTexture(this._sizes.texwidth, this._sizes.texheight, false,
+      BABYLON.Texture.NEAREST_SAMPLINGMODE);
+
+    gl.bindTexture(gl.TEXTURE_2D, this._texture._texture);
+
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.NEAREST);
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.NEAREST);
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE);
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE);
+    this._type.texImage2D(gl, this._sizes.texwidth, this._sizes.texheight, undefined);
+
+    gl.bindTexture(gl.TEXTURE_2D, null);
+
+    this._texture._texture.isReady = true;
+  }
+
+  private _set(lo: number, hi: number, mode: number, history: { pos: number, lo: number, hi: number }[]): boolean {
+    const pos = this._hashfunctions[mode].compute(lo, hi) % this._sizes.maxsize;
+    const [loOld, hiOld] = this._getValue(pos);
+
+    if (loOld === 0 && hiOld === 0) {
+      this.clearLastInsertError();
+
+      this._setValue(pos, lo, hi);
+      ++this._setElements;
+      if (this.loadFactor > 0.5 && this._sizes.level + 1 < Cuckoo._sizeLookup.length) {
+        return this._resize();
+      }
+      return true;
+    } else if (loOld === lo && hiOld === hi) {
+      return true;
+    } else {
+      // Check for circuit
+      if (history.find((el) => { return el.pos === pos && el.hi === hi && el.lo === lo; })) {
+        console.log(`Collision can\'t be resolved! (Load factor: ${this.loadFactor})`);
+        this._lastInsertError = { lo: lo, hi: hi };
+        return false;
+      } else {
+        this._setValue(pos, lo, hi);
+
+        // Check which seed was used for old segment and switch to alternative for new insertion
+        const posOld = this._hashfunctions[mode].compute(loOld, hiOld) % this._sizes.maxsize;
+
+        if (posOld === pos) {
+          mode = 1 - mode;
+        }
+
+        history.push({ pos: pos, lo: lo, hi: hi });
+        return this._set(loOld, hiOld, mode, history);
+      }
+    }
+  }
+
+  private _getValue(pos: number): [number, number] {
+    return this._type.getBufferValue(this._tableView, pos);
+  }
+
+  private _setValue(pos: number, lo: number, hi: number = 0): void {
+    const gl = this._scene.getEngine()._gl as WebGL2RenderingContext;
+
+    const x_pos = pos % this._sizes.texwidth;
+    const y_pos = Math.floor(pos / this._sizes.texwidth);
+
+    this._type.setBufferValue(this._tableView, pos, lo, hi);
+
+    gl.bindTexture(gl.TEXTURE_2D, this._texture._texture);
+    this._type.texSubImage2D(gl, x_pos, y_pos, lo, hi);
+    gl.bindTexture(gl.TEXTURE_2D, null);
+
+  }
+}

--- a/src/babylon/tools/data/HashFunction.tsx
+++ b/src/babylon/tools/data/HashFunction.tsx
@@ -1,0 +1,110 @@
+export type hashtype = 'murmur' | 'fnv1a' | 'identity';
+
+export default class HashFunction {
+  /* Constants */
+  // Murmur3
+  private static readonly _murmur3_32_c1 = 0xcc9e2d51;
+  private static readonly _murmur3_32_c2 = 0x1b873593;
+  private static readonly _murmur3_32_n = 0xe6546b64;
+  private static readonly _murmur3_32_mix1 = 0x85ebca6b;
+  private static readonly _murmur3_32_mix2 = 0xc2b2ae35;
+
+  // FNV-1a
+  private static readonly _fnv_offset_32 = 0x811c9dc5;
+  private static readonly _fnv_prime_32 = 16777619;
+
+  private _hashfunc: (lo: number, hi: number) => number;
+
+  public static createHashFunctions(a: hashtype, b: hashtype): [HashFunction, HashFunction] {
+    return [new HashFunction(a), new HashFunction(b)];
+  }
+
+  /* tslint:disable:no-bitwise */
+  /* Hash Functions */
+  // Simple
+  // This fine-tuned hash function was higly optimized for GPU lookup speed :D
+  public static identity_32(k: number): number {
+    return k >>> 0;
+  }
+
+  // Murmur3
+  // https://en.wikipedia.org/wiki/MurmurHash
+  public static murmur3_32(k: number, seed: number): number {
+    k = this._x86Multiply(k, this._murmur3_32_c1);
+    k = this._x86Rotl(k, 15);
+    k = this._x86Multiply(k, this._murmur3_32_c2);
+
+    let h = seed;
+    h ^= k;
+    h = this._x86Rotl(h, 13);
+    h = this._x86Multiply(h, 5) + this._murmur3_32_n;
+
+    h ^= 4;
+    h ^= h >>> 16;
+    h = this._x86Multiply(h, this._murmur3_32_mix1);
+    h ^= h >>> 13;
+    h = this._x86Multiply(h, this._murmur3_32_mix2);
+    h ^= h >>> 16;
+
+    return h >>> 0;
+  }
+
+  // FNV-1a (with seed)
+  // https://en.wikipedia.org/wiki/Fowler-Noll-Vo_hash_function
+  public static fnv1a_32(k: number, seed: number = this._fnv_offset_32): number {
+    let h = seed;
+    h ^= (k & 0xFF000000) >>> 24;
+    h = this._x86Multiply(h, this._fnv_prime_32);
+    h ^= (k & 0x00FF0000) >>> 16;
+    h = this._x86Multiply(h, this._fnv_prime_32);
+    h ^= (k & 0x0000FF00) >>> 8;
+    h = this._x86Multiply(h, this._fnv_prime_32);
+    h ^= (k & 0x000000FF) >>> 0;
+    h = this._x86Multiply(h, this._fnv_prime_32);
+
+    return h >>> 0;
+  }
+
+  public static combineUInt32(m: number, n: number) {
+    return (m ^ (n + 0x517cc1b7 + (n << 6) + (n >>> 2))) >>> 0;
+  }
+
+  private static _x86Multiply(m: number, n: number) {
+    return ((m & 0xffff) * n) + ((((m >>> 16) * n) & 0xffff) << 16);
+  }
+
+  private static _x86Rotl(m: number, n: number) {
+    return (m << n) | (m >>> (32 - n));
+  }
+  /* tslint:enable:no-bitwise */
+
+  /* Hash Object */
+  constructor(private _mode: hashtype, private _seed: number = Math.floor(Math.random() * 0x01000000)) {
+    if (this._mode === 'murmur') {
+      this._hashfunc = (lo, hi): number => {
+        return HashFunction.combineUInt32(
+          HashFunction.murmur3_32(lo, this._seed), HashFunction.murmur3_32(hi, this._seed));
+      };
+    } else if (this._mode === 'fnv1a') {
+      this._hashfunc = (lo, hi): number => {
+        return HashFunction.combineUInt32(
+          HashFunction.fnv1a_32(lo, this._seed), HashFunction.fnv1a_32(hi, this._seed));
+      };
+    } else if (this._mode === 'identity') {
+      this._hashfunc = (lo, hi): number => {
+        return HashFunction.combineUInt32(
+          HashFunction.identity_32(lo), HashFunction.identity_32(hi));
+      };
+    }
+  }
+
+  public compute(lo: number, hi: number = 0): number {
+    return this._hashfunc(lo, hi);
+  }
+
+  get seed() {
+    return this._seed;
+  }
+
+
+}

--- a/src/types/uint64.tsx
+++ b/src/types/uint64.tsx
@@ -1,0 +1,3 @@
+export default class UInt64 {
+  constructor(public low: number, public high: number = 0) { };
+}


### PR DESCRIPTION
Cuckoo Hashing for uint8, uint16, uint32, uint64 and float32 values -- although only tested with uint64
Three hashing functions are available: Identity, Murmur3 and FNV-1a.
By default it is using [Identity, FNV-1a]. Changing those requires modifications to the shader as well.

